### PR TITLE
Potential fix for code scanning alert no. 1: Inefficient regular expression

### DIFF
--- a/src/lib/shares/re.ts
+++ b/src/lib/shares/re.ts
@@ -178,7 +178,7 @@ export const regexp = {
 	) as RegExp,
 	//list
 	reList: compile(
-		/^((?:[:txlisthd:][^\0]*?(?:\r?\n|$))+)(\s*\n|$)/,
+		/^((?:[:txlisthd:][^\0\n]*(?:\r?\n|$))+)(\s*\n|$)/,
 		"s",
 	) as RegExp,
 	reItem: compile(/^([#*]+)([^\0]+?)(\n(?=[:txlisthd2:])|$)/, "s") as RegExp,


### PR DESCRIPTION
Potential fix for [https://github.com/phothinmg/ts-textile/security/code-scanning/1](https://github.com/phothinmg/ts-textile/security/code-scanning/1)

To fix the problem, we need to rewrite the regular expression to eliminate the ambiguity caused by `[^\0]*?`. Specifically, we should make the repetition more explicit by restricting it to match characters that cannot cause overlapping matches. This may involve excluding specific problematic characters (such as `:`) or splitting the regular expression into distinct parts to avoid backtracking. The replacement expression should maintain the functionality of matching the same patterns while ensuring that each match is deterministic.

For the highlighted regular expression at line 181, the `[^\0]*?` part can be modified to exclude problematic characters like `:` explicitly, or restructured to avoid ambiguity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
